### PR TITLE
VIH-7419 - use base url alone to get to login

### DIFF
--- a/AcceptanceTests/AcceptanceTests.Tests/DriverTests/DesktopLocal.cs
+++ b/AcceptanceTests/AcceptanceTests.Tests/DriverTests/DesktopLocal.cs
@@ -101,7 +101,7 @@ namespace AcceptanceTests.Tests.DriverTests
         private void RunTest()
         {
             _browser.LaunchBrowser();
-            _browser.NavigateToPage(_config.Url);
+            _browser.NavigateToPage();
             Thread.Sleep(TimeSpan.FromSeconds(4));
             _browser.Driver.Title.Should().Contain("Sign in to your account");
         }
@@ -109,7 +109,7 @@ namespace AcceptanceTests.Tests.DriverTests
         private void RunIETest()
         {
             _browser.LaunchBrowser();
-            _browser.NavigateToPage(_config.Url);
+            _browser.NavigateToPage();
             Thread.Sleep(TimeSpan.FromSeconds(4));
             _browser.Driver.Title.Should().Contain("Video Hearings");
         }


### PR DESCRIPTION
Fix on URL's, default is a base address and that's all that's needed for login.

**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/VIH-7419

### Change description ###



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
