### PR TITLE
VIH-8065 - use latest Ubuntu VM

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,7 +17,7 @@ resources:
     endpoint: sspublicsbox
 
 pool:
-  vmImage: ubuntu-16.04
+  vmImage: ubuntu-latest
 
 container: dotnetsdk
 


### PR DESCRIPTION
Use Ubuntu-latest as vmImage instead of a specific build as they become deprecated.

**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###



### Change description ###



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
