### PR TITLE
VIH-8021 - null check on Uri object when initialising the remote driver

### DIFF
--- a/AcceptanceTests/AcceptanceTests.Common/Driver/Drivers/Desktop/Mac/ChromeMacDriverStrategy.cs
+++ b/AcceptanceTests/AcceptanceTests.Common/Driver/Drivers/Desktop/Mac/ChromeMacDriverStrategy.cs
@@ -25,7 +25,9 @@ namespace AcceptanceTests.Common.Driver.Drivers.Desktop.Mac
             options.AddArgument("use-fake-device-for-media-stream");
             options.AddAdditionalCapability("sauce:options", SauceOptions, true);
 
-            return new RemoteWebDriver(new Uri(Uri.AbsolutePath), options.ToCapabilities());
+            return Uri != null
+                ? new RemoteWebDriver(new Uri(Uri.AbsolutePath), options.ToCapabilities())
+                : new RemoteWebDriver(Uri, options.ToCapabilities());
         }
 
         public override IWebDriver InitialiseForLocal()

--- a/AcceptanceTests/AcceptanceTests.Common/Driver/Drivers/Desktop/Windows/ChromeWindowsDriverStrategy.cs
+++ b/AcceptanceTests/AcceptanceTests.Common/Driver/Drivers/Desktop/Windows/ChromeWindowsDriverStrategy.cs
@@ -24,7 +24,9 @@ namespace AcceptanceTests.Common.Driver.Drivers.Desktop.Windows
             options.AddArgument("use-fake-device-for-media-stream");
             options.AddAdditionalCapability("sauce:options", SauceOptions, true);
 
-            return new RemoteWebDriver(new Uri(Uri.AbsolutePath), options.ToCapabilities());
+            return Uri != null
+                ? new RemoteWebDriver(new Uri(Uri.AbsolutePath), options.ToCapabilities())
+                : new RemoteWebDriver(Uri, options.ToCapabilities());
         }
 
         public override IWebDriver InitialiseForLocal()


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-8021


### Change description ###
null check on Uri object when initialising the remote driver

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
