### PR TITLE
VIH-8021 - removal of extra url in running tests and added Uri.AbsoluteUri in remote driver

### DIFF
--- a/AcceptanceTests/AcceptanceTests.Common/Driver/Drivers/Desktop/Windows/ChromeWindowsDriverStrategy.cs
+++ b/AcceptanceTests/AcceptanceTests.Common/Driver/Drivers/Desktop/Windows/ChromeWindowsDriverStrategy.cs
@@ -17,7 +17,7 @@ namespace AcceptanceTests.Common.Driver.Drivers.Desktop.Windows
                 AcceptInsecureCertificates = true
             };
 
-            //if (LoggingEnabled)
+            if (LoggingEnabled)
                 SauceOptions.Add("extendedDebugging", true);
 
             options.AddArgument("use-fake-ui-for-media-stream");
@@ -27,8 +27,8 @@ namespace AcceptanceTests.Common.Driver.Drivers.Desktop.Windows
 
             if (Uri != null && Uri.AbsoluteUri != null)
             {
-                NUnit.Framework.TestContext.WriteLine($"uri for Windows is not null = {Uri.AbsolutePath}");
-                return new RemoteWebDriver(new Uri(Uri.AbsolutePath), options.ToCapabilities(), TimeSpan.FromSeconds(30));
+                NUnit.Framework.TestContext.WriteLine($"uri for Windows is not null = {Uri.AbsoluteUri}");
+                return new RemoteWebDriver(new Uri(Uri.AbsoluteUri), options.ToCapabilities(), TimeSpan.FromSeconds(30));
              }
             else {
                 NUnit.Framework.TestContext.WriteLine($"uri for Windows is null = {Uri}");

--- a/AcceptanceTests/AcceptanceTests.Tests/DriverTests/DesktopLocal.cs
+++ b/AcceptanceTests/AcceptanceTests.Tests/DriverTests/DesktopLocal.cs
@@ -101,7 +101,7 @@ namespace AcceptanceTests.Tests.DriverTests
         private void RunTest()
         {
             _browser.LaunchBrowser();
-            _browser.NavigateToPage(_config.Url);
+            _browser.NavigateToPage();
             Thread.Sleep(TimeSpan.FromSeconds(4));
             _browser.Driver.Title.Should().Contain("Sign in to your account");
         }


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-8021


### Change description ###
- Removed uri variable that was provided in tests as it was provided twice and was causing "Page Not Found" error

- The Uri.AbsoluteUri property does have the complete uri which works locally.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
