### PR TITLE
VIH-9375 Bump nuget package version

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,0 +1,5 @@
+mode: Mainline
+branches: {}
+ignore:
+  sha: []
+merge-message-formats: {}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-9375


### Change description ###
Adds a commit to bump the generated nuget package version to the next minor version

Also adds the GitVersion.yml back in that was previously deleted, required for this version of gitversion

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
